### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/lib/dataOrchestration.js
+++ b/lib/dataOrchestration.js
@@ -42,7 +42,10 @@ function sanitizeHtmlText(text, preserveLineBreaks = true) {
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&'); // Must be last
 
-  // Step 4: Clean up extra whitespace (but preserve intentional newlines)
+  // Step 4: Remove any remaining angle brackets to prevent re-formed tags
+  result = result.replace(/[<>]/g, '');
+
+  // Step 5: Clean up extra whitespace (but preserve intentional newlines)
   result = result.replace(/\s+/g, ' ').trim();
 
   return result;


### PR DESCRIPTION
Potential fix for [https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/2](https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/2)

In general, we need to ensure that unsafe HTML constructs cannot reappear after sanitization, especially due to the order and nature of regex replacements. Specifically here, decoding HTML entities after stripping tags can convert safe-looking entity sequences into literal tag delimiters (`<`, `>`), potentially producing `<script` or other tags that were never processed by the tag-removal regex. To fix this, we should either (a) use a robust HTML-sanitization library that handles entities and tags correctly, or (b) adjust our logic so that after entity decoding, we prevent any `<` or `>` characters from remaining in the output, thus ensuring no HTML element injection is possible.

The minimal change that preserves existing behavior as much as possible is: keep steps 1–3 as they are (including the specific entity decodings and line-break handling), then add a post-processing step that strips any remaining `<` and `>` characters after entity decoding, and finally do the whitespace normalization. This way, even if `&lt;script&gt;` slips past the tag-removal regex and is decoded later to `<script>`, the subsequent character-level sanitization will remove the `<` and `>` characters, leaving harmless plain text like `script`. This addresses the multi-character sanitization concern because we are no longer relying on a complex multi-character tag regex after decoding; we simply ensure that the tag-delimiter characters cannot survive.

Concretely in `lib/dataOrchestration.js`, inside `sanitizeHtmlText`:

- Keep the existing logic up through the entity-decoding block (`.replace(/&amp;/g, '&')`).
- Immediately after that, add a new step that removes any `<` or `>` characters: `result = result.replace(/[<>]/g, '');`.
- Update the comments to make clear that after decoding entities we strip any remaining angle brackets before doing the whitespace normalization.
- Leave the rest of the file unchanged.

No additional imports or external libraries are strictly required for this targeted fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
