### PR TITLE
fix: trigger backend initialization via DOM_OBJECTS_CREATED

### DIFF
--- a/MMM-Webuntis.js
+++ b/MMM-Webuntis.js
@@ -1663,6 +1663,14 @@ Module.register('MMM-Webuntis', {
         this._log('warn', 'Please update your config.js to use the new configuration format.');
         this._log('warn', 'See the module documentation for migration details.');
       }
+
+      // Trigger backend initialization now that DOM is ready and sockets are connected.
+      // MagicMirror does NOT call resume() on modules at startup (only after hide→show),
+      // so we must trigger init here instead of deferring to resume().
+      if (!this._isDemoModeEnabled() && !this._initialized && !this._initRequested) {
+        this._initRequested = true;
+        this._sendInit('dom-objects-created');
+      }
     }
   },
 


### PR DESCRIPTION
## Problem

MagicMirror does not call `resume()` on modules that are visible from startup — `resume()` is only invoked after `hide()→show()` via `module.show()` ([module.js L408](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/js/module.js#L408)).

This means the module never sends `INIT_MODULE` to the backend and remains blank forever on a normal (non-carousel) setup.

## Fix

Add a `DOM_OBJECTS_CREATED` notification handler in `notificationReceived()` that triggers `_sendInit()` when the module hasn't been initialized yet. This ensures the backend pipeline starts regardless of visibility lifecycle.


## Files Changed

- `MMM-Webuntis.js` (+8 lines)

## Testing

Tested on Raspberry Pi 4 running MagicMirror v2.34.0 in both Electron and serveronly modes. Module consistently initializes and displays timetable data on startup.

Closes #37 (partially)