### PR TITLE
fix: use single AbortController for full request lifecycle

### DIFF
--- a/lib/webuntis/fetchClient.js
+++ b/lib/webuntis/fetchClient.js
@@ -144,9 +144,15 @@ async function get(url, config = {}) {
 async function request(config) {
   const { url, method = 'GET', data, headers = {}, timeout = 30000, ...restConfig } = config;
 
+  // Use a single AbortController for the ENTIRE operation (headers + body reading)
+  // fetchWithTimeout only covers until headers arrive; body reading can hang indefinitely
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
   const options = {
     method: method.toUpperCase(),
     headers,
+    signal: controller.signal,
     ...restConfig,
   };
 
@@ -155,16 +161,27 @@ async function request(config) {
     options.body = JSON.stringify(data);
   }
 
-  const response = await fetchWithTimeout(url, options, timeout);
+  try {
+    const response = await fetch(url, options);
 
-  ensureSuccessResponse(response, method.toUpperCase());
+    ensureSuccessResponse(response, method.toUpperCase());
 
-  return {
-    data: await parseJSON(response),
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  };
+    const parsed = await parseJSON(response);
+    clearTimeout(timeoutId);
+
+    return {
+      data: parsed,
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timeout after ${timeout}ms`, { cause: error });
+    }
+    throw error;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Problem

`fetchWithTimeout()` only covers the time until response headers arrive. If the server sends headers but the body transfer stalls or hangs, `parseJSON()` blocks indefinitely with no timeout protection.

This can cause the module to freeze silently when the WebUntis API responds with headers but delays the body (e.g., during server overload or network issues).

## Fix

Replace the two-phase approach (`fetchWithTimeout` for headers, then unprotected body read) with a single `AbortController` that wraps both `fetch()` and `parseJSON()` phases. The configured timeout now applies to the entire operation.

On abort, the `AbortError` is mapped to a descriptive timeout message including the configured duration for easier debugging.

## Files Changed

- `lib/webuntis/fetchClient.js` (+25/-8)

## Testing

Tested on Raspberry Pi 4 with MagicMirror v2.34.0. Verified that:
- Normal requests complete successfully with timeout cleared
- Simulated slow body responses trigger the timeout correctly
- Error messages include the configured timeout duration

Closes #37 (partially)