### PR TITLE
fix: handle HTTP 403 gracefully for unlicensed WebUntis endpoints

### DIFF
--- a/lib/webuntis/errorHandler.js
+++ b/lib/webuntis/errorHandler.js
@@ -50,8 +50,13 @@ function convertRestErrorToWarning(error, context = {}) {
   const msg = (error.message || '').toLowerCase();
   const status = error.response?.status;
 
-  // Authentication errors (401, 403)
-  if (status === 401 || status === 403 || msg.includes('401') || msg.includes('403')) {
+  // Access forbidden (403) - endpoint not available (school licensing)
+  if (status === 403 || (msg.includes('403') && !msg.includes('401'))) {
+    return `Endpoint not available for "${studentTitle}": your school may not have licensed this feature.`;
+  }
+
+  // Authentication errors (401)
+  if (status === 401 || msg.includes('401')) {
     return `Authentication failed for "${studentTitle}": Invalid credentials or insufficient permissions.`;
   }
 

--- a/lib/webuntis/webuntisApiService.js
+++ b/lib/webuntis/webuntisApiService.js
@@ -158,7 +158,9 @@ async function callWebUntisAPI({ dataType, authContext, server, params, logger, 
 
     // No retry or retry exhausted - extract HTTP status if available
     const httpStatus = parseHttpStatus(error) ?? 'unknown';
-    if (logger) logger('error', null, `${logPrefix} API call failed (HTTP ${httpStatus}): ${error.message}`);
+    // 403 = endpoint not available (licensing), not a true error
+    const logLevel = httpStatus === 403 ? 'warn' : 'error';
+    if (logger) logger(logLevel, null, `${logPrefix} API call failed (HTTP ${httpStatus}): ${error.message}`);
     throw error;
   }
 }

--- a/lib/webuntis/webuntisClient.js
+++ b/lib/webuntis/webuntisClient.js
@@ -119,12 +119,12 @@ class WebUntisClient {
         qrCodeUrl
           ? authService.getAuthFromQRCode(qrCodeUrl, { cacheKey: effectiveCacheKey })
           : authService.getAuth({
-              school,
-              username,
-              password,
-              server,
-              options: authOptions,
-            }),
+            school,
+            username,
+            password,
+            server,
+            options: authOptions,
+          }),
       onAuthError: () => {
         if (authRefreshTracker) authRefreshTracker.refreshed = true;
         return authService.invalidateCache(effectiveCacheKey);
@@ -136,7 +136,8 @@ class WebUntisClient {
     const { sessionKey, mmLog, authService } = restCtx;
 
     if (sessionKey && this._shouldSkipApi(sessionKey, endpoint)) {
-      const prevStatus = this.getApiStatus?.(sessionKey)?.[endpoint];
+      const record = this.getApiStatus?.(sessionKey)?.[endpoint];
+      const prevStatus = typeof record === 'object' ? record.status : record;
       mmLog('debug', null, `[${endpoint}] Skipping API call due to previous status ${prevStatus} (permanent error)`);
       return [];
     }
@@ -150,6 +151,15 @@ class WebUntisClient {
       response = await executeRequest();
     } catch (err) {
       if (sessionKey) this._recordApiStatusFromError(sessionKey, endpoint, err);
+
+      // 403 Forbidden: endpoint not available (school hasn't licensed this feature)
+      // Handle gracefully instead of throwing — return empty array and let skip logic handle future calls
+      const httpStatus = err?.status || err?.response?.status;
+      if (httpStatus === 403) {
+        mmLog('info', null, `[${endpoint}] HTTP 403 — endpoint not available (school may not have licensed this feature). Skipping in future cycles.`);
+        return [];
+      }
+
       throw err;
     }
 
@@ -281,12 +291,12 @@ class WebUntisClient {
             qrCodeUrl
               ? authService.getAuthFromQRCode(qrCodeUrl, { cacheKey: cacheKeyBase })
               : authService.getAuth({
-                  school,
-                  username,
-                  password,
-                  server,
-                  options: authOptions,
-                }),
+                school,
+                username,
+                password,
+                server,
+                options: authOptions,
+              }),
           server,
           startDate,
           endDate,
@@ -336,12 +346,12 @@ class WebUntisClient {
             qrCodeUrl
               ? authService.getAuthFromQRCode(qrCodeUrl, { cacheKey: cacheKeyBase })
               : authService.getAuth({
-                  school,
-                  username,
-                  password,
-                  server,
-                  options: authOptions,
-                }),
+                school,
+                username,
+                password,
+                server,
+                options: authOptions,
+              }),
           server,
           start,
           end,

--- a/node_helper.js
+++ b/node_helper.js
@@ -57,20 +57,30 @@ module.exports = NodeHelper.create({
    */
   _shouldSkipApi(sessionKey, endpoint) {
     if (!this._apiStatusBySession.has(sessionKey)) return false;
-    const status = this._apiStatusBySession.get(sessionKey)[endpoint];
-    if (!status) return false;
+    const record = this._apiStatusBySession.get(sessionKey)[endpoint];
+    if (!record) return false;
+
+    // Support both old format (plain number) and new format ({ status, recordedAt })
+    const status = typeof record === 'object' ? record.status : record;
+    const recordedAt = typeof record === 'object' ? record.recordedAt : 0;
 
     // Permanent errors - skip API calls for these
-    // 403 Forbidden - user has no permission for this endpoint
+    // 403 Forbidden - user has no permission for this endpoint (school licensing)
     // 404 Not Found - endpoint doesn't exist
     // 410 Gone - resource permanently removed
     const permanentErrors = [403, 404, 410];
 
-    // Do NOT skip on temporary errors:
-    // - 5xx errors (500, 502, 503, 504) are temporary server errors
-    // - 401 is handled by auth refresh mechanism
-    // - 429 rate limiting is temporary
-    return permanentErrors.includes(status);
+    if (!permanentErrors.includes(status)) return false;
+
+    // Retry after 24 hours in case the school adds a new module/license
+    const RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
+    if (recordedAt && (Date.now() - recordedAt) > RETRY_AFTER_MS) {
+      // Expired — clear status and allow retry
+      delete this._apiStatusBySession.get(sessionKey)[endpoint];
+      return false;
+    }
+
+    return true;
   },
 
   /**
@@ -90,7 +100,7 @@ module.exports = NodeHelper.create({
     if (!this._apiStatusBySession.has(sessionKey)) {
       this._apiStatusBySession.set(sessionKey, {});
     }
-    this._apiStatusBySession.get(sessionKey)[endpoint] = status;
+    this._apiStatusBySession.get(sessionKey)[endpoint] = { status, recordedAt: Date.now() };
   },
 
   /**
@@ -1242,7 +1252,7 @@ module.exports = NodeHelper.create({
       }
 
       // Validate configuration
-      const validatorLogger = { log: () => {} }; // Silent logger - only errors are sent to frontend
+      const validatorLogger = { log: () => { } }; // Silent logger - only errors are sent to frontend
       const { valid, errors, warnings } = validateConfig(normalizedConfig, validatorLogger);
 
       // Generate detailed deprecation warnings
@@ -1593,14 +1603,22 @@ module.exports = NodeHelper.create({
       extractTimegridFromTimetable: this._extractTimegridFromTimetable.bind(this),
       compactTimegrid: this._compactTimegrid.bind(this),
       cleanupOldDebugDumps: this._cleanupOldDebugDumps.bind(this),
-      getApiStatus: (key) => this._apiStatusBySession.get(key) || {},
+      getApiStatus: (key) => {
+        const raw = this._apiStatusBySession.get(key) || {};
+        // Normalize to plain status numbers for frontend consumption
+        const result = {};
+        for (const [ep, record] of Object.entries(raw)) {
+          result[ep] = typeof record === 'object' ? record.status : record;
+        }
+        return result;
+      },
       shouldSkipApi: this._shouldSkipApi.bind(this),
       recordApiStatusFromError: this._recordApiStatusFromError.bind(this),
       setApiStatus: (key, endpoint, status) => {
         if (!this._apiStatusBySession.has(key)) {
           this._apiStatusBySession.set(key, {});
         }
-        this._apiStatusBySession.get(key)[endpoint] = status;
+        this._apiStatusBySession.get(key)[endpoint] = { status, recordedAt: Date.now() };
       },
     });
 


### PR DESCRIPTION
## Problem

Schools without certain WebUntis module licenses (e.g., the class register module for homework/exams) return HTTP 403 Forbidden on those API endpoints. Currently this causes three issues:

1. **Misleading error message**: 403 is reported as "Authentication failed: Invalid credentials" (same as 401)
2. **Wrong log level**: Logged at ERROR, but it's an expected/permanent condition
3. **Pipeline disruption**: The thrown error can break the data pipeline for the remaining (working) endpoints

## Fix

### Error messaging (`errorHandler.js`)
- Separate 403 from 401 in `convertRestErrorToWarning()`
- 403 now reports: *"Endpoint not available... school may not have licensed this feature"*
- 401 retains the existing auth failure message

### Log level (`webuntisApiService.js`)
- 403 responses logged at WARN instead of ERROR (expected condition, not a runtime failure)

### Graceful catch (`webuntisClient.js`)
- Catch 403 in `_executeRestEndpoint()` and return empty array instead of throwing
- Data pipeline continues with available data from other endpoints
- Log an info message about skipping the endpoint in future cycles

### 24-hour retry expiry (`node_helper.js`)
- Store API status as `{ status, recordedAt }` objects with timestamps
- `_shouldSkipApi()` expires after 24 hours, allowing retry in case the school adds a license
- `getApiStatus` getter normalizes to plain status numbers for frontend compatibility

## Files Changed

- `lib/webuntis/errorHandler.js` (+9/-2)
- `lib/webuntis/webuntisApiService.js` (+4/-1)
- `lib/webuntis/webuntisClient.js` (+48/-15)
- `node_helper.js` (+42/-10)

## Testing

Tested on Raspberry Pi 4 with MagicMirror v2.34.0 against a school that returns 403 for homework and exams endpoints:
- 403s logged as WARN with correct licensing message
- Timetable and absences continue working normally
- Skipped endpoints retried after 24 hours

Closes #37