### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete multi-character sanitization

### DIFF
--- a/lib/webuntis/dataOrchestration.js
+++ b/lib/webuntis/dataOrchestration.js
@@ -38,8 +38,14 @@ function stripAllHtml(text, preserveLineBreaks = true) {
     result = result.replace(/<br\s*\/?>/gi, '\n');
   }
 
-  // As a safety net, strip any leftover tags that might remain
-  result = result.replace(/<[^>]*>/g, '');
+  // As a safety net, strip any leftover tags that might remain.
+  // Apply repeatedly until no further changes occur to avoid incomplete
+  // multi-character sanitization where removing one tag exposes another.
+  let previous;
+  do {
+    previous = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== previous);
 
   if (preserveLineBreaks) {
     // Normalize whitespace but keep single newlines


### PR DESCRIPTION
Potential fix for [https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/12](https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/12)

In general, the problem arises because a regex like `/\<[^>]*\>/g` may remove a multi-character fragment in such a way that what remains now contains a new tag-like sequence that was not present (and thus not matched) in the original string. Applying the replacement just once can therefore leave tag-like text, which is what CodeQL is warning about. The typical mitigation is to either (a) use a robust sanitization library (already done here via `sanitize-html`), or (b) if you keep the regex, apply it repeatedly until no more matches occur, ensuring the result is stable.

The minimal, behavior-preserving fix here is to make the “safety net” regex on line 42 iterative: loop until no further `<...>` patterns are found and removed. This avoids any scenario where removal of one tag causes another to appear, and it directly addresses “incomplete multi-character sanitization” without changing what the function does on already-clean input. Concretely, in `lib/webuntis/dataOrchestration.js`, inside `stripAllHtml`, replace the single call:

```js
result = result.replace(/<[^>]*>/g, '');
```

with a small loop that re-runs the replacement until the string stops changing:

```js
let previous;
do {
  previous = result;
  result = result.replace(/<[^>]*>/g, '');
} while (result !== previous);
```

No new imports are needed, and no other parts of the file need to change. This keeps external behavior the same while satisfying the CodeQL rule and hardening the defense-in-depth cleanup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
