### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/lib/payloadCompactor.js
+++ b/lib/payloadCompactor.js
@@ -274,13 +274,14 @@ function sanitizeHtml(text, allowMarkdown = false) {
   });
 
   // Decode common HTML entities
+  // Decode '&amp;' last to avoid double-unescaping sequences like '&amp;lt;'
   result = result
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
 
   // Clean up: remove markdown formatting chars if not allowed
   if (!allowMarkdown) result = result.replace(/[_*]/g, '');


### PR DESCRIPTION
Potential fix for [https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/1](https://github.com/HeikoGr/MMM-Webuntis/security/code-scanning/1)

In general, to avoid double unescaping when decoding HTML entities, you must unescape the “escape character” entity (`&amp;`) last, not first. That way, text like `&amp;lt;` remains the literal string `&lt;` instead of becoming `<` via two decoding steps. The fix is to reorder the replacement chain so that `&lt;`, `&gt;`, `&quot;`, `&#39;`, and `&nbsp;` are decoded before `&amp;`.

Concretely, in `lib/payloadCompactor.js` inside `sanitizeHtml`, we will modify the block at lines 276–283 where `result` is passed through a series of `.replace` calls. We will keep the same set of entities and the same mappings, but we will move the `.replace(/&amp;/g, '&')` call to *after* all other entity replacements. No additional imports or helper methods are needed, as this is simple string replacement. Existing behavior for normal inputs (like `&quot;hello&quot;`) is preserved; only pathological / nested cases change, now behaving safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
